### PR TITLE
Refactor resource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM main as testing
 
 RUN set -eux \
  && apk update \
- && apk ruby wget \
+ && apk add ruby wget \
  && gem install rspec \
  && wget -q -O - https://raw.githubusercontent.com/troykinsella/mockleton/master/install.sh | bash \
  && cp /usr/local/bin/mockleton /usr/bin/docker \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,29 @@
-FROM ubuntu:bionic as main
+FROM docker/compose:1.24.1 as main
 LABEL maintainer="Troy Kinsella <troy.kinsella@gmail.com>"
 
-ADD https://github.com/docker/compose/releases/download/1.24.1/docker-compose-linux-x86_64 /usr/local/bin/docker-compose
-
-RUN set -eux; \
-    chmod +x /usr/local/bin/docker-compose; \
-    apt-get update; \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y \
-      curl \
-      gnupg \
-      jq; \
-    \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -; \
-    echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" >> /etc/apt/sources.list; \
-    apt-get update; \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y \
-      docker-ce-cli; \
-    DEBIAN_FRONTEND=noninteractive apt-get remove -y \
-      gnupg \
-      curl; \
-    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y; \
-    apt-get clean all; \
-    rm -rf /var/lib/apt/lists/*
+RUN set -eux \
+ && apk update \
+ && apk upgrade \
+ && apk add bash jq \
+ && rm -rf /var/cache/apk/*
 
 COPY assets/* /opt/resource/
 
 FROM main as testing
 
-RUN set -eux; \
-    apt-get update; \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y \
-      ruby \
-      wget; \
-    gem install \
-      rspec; \
-    wget -q -O - https://raw.githubusercontent.com/troykinsella/mockleton/master/install.sh | bash; \
-    cp /usr/local/bin/mockleton /usr/bin/docker; \
-    cp /usr/local/bin/mockleton /usr/local/bin/docker-compose;
+RUN set -eux \
+ && apk update \
+ && apk ruby wget \
+ && gem install rspec \
+ && wget -q -O - https://raw.githubusercontent.com/troykinsella/mockleton/master/install.sh | bash \
+ && cp /usr/local/bin/mockleton /usr/bin/docker \
+ && cp /usr/local/bin/mockleton /usr/local/bin/docker-compose \
+ && rm -rf /var/cache/apk/*
 
 COPY . /resource/
 
-RUN set -eux; \
-    cd /resource; \
-    rspec
-
+RUN set -eux \
+ && cd /resource \
+ && rspec
 
 FROM main

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ FROM main as testing
 
 RUN set -eux \
  && apk update \
- && apk add ruby wget \
- && gem install rspec \
+ && apk add ruby ruby-json wget \
+ && gem install rspec --no-ri --no-rdoc \
  && wget -q -O - https://raw.githubusercontent.com/troykinsella/mockleton/master/install.sh | bash \
  && cp /usr/local/bin/mockleton /usr/bin/docker \
  && cp /usr/local/bin/mockleton /usr/local/bin/docker-compose \

--- a/assets/out
+++ b/assets/out
@@ -273,6 +273,7 @@ if [ "$pull" == "true" ]; then
 fi
 
 docker-compose \
+  --no-ansi \
   --host $host:$port \
   -f $compose_file \
   $(tlsverify) \
@@ -285,4 +286,8 @@ if [ -n "$wait_after" ]; then
   sleep $wait_after
 fi
 
-printf '{"version":{}}' >&3
+jq -n "{
+  version: {
+    digest: $((echo -n "sha256:"; sha256sum $compose_file) | cut -d ' ' -f1 | jq -R .)
+  }
+}" >&3

--- a/assets/out
+++ b/assets/out
@@ -152,7 +152,7 @@ up_command_options() {
 }
 
 service_arguments() {
-  local services=$(jq -r '.params.services | join(" ")' < $payload)
+  local services=$(jq -r '.params.services // [] | join(" ")' < $payload)
   echo $services
 }
 

--- a/assets/out
+++ b/assets/out
@@ -218,6 +218,21 @@ validate_command() {
   esac
 }
 
+tlsverify() {
+  local tls=$(jq -r '.source.tlsverify // ""' < $payload)
+  [ -z "$tls" ] && return
+  local client_home="$HOME/.docker"
+  mkdir -p "$client_home"
+  
+  for key in ca cert key; do
+    local value=$(jq -r ".source.tlsverify.${key}" < $payload)
+    [ -z "$value" ] && echo "ERROR: 'source.tlsverify.$key' must be defined" && exit 1
+    echo "$value" > "${client_home}/${key}.pem"
+  done
+
+  echo -n "--tlsverify "
+}
+
 host=$(jq -r '.source.host // ""' < $payload)
 test -z "$host" && { echo '"source.host" must be defined' >&2; exit 1; }
 port=$(jq -r '.source.port // "2376"' < $payload)
@@ -260,6 +275,7 @@ fi
 docker-compose \
   --host $host:$port \
   -f $compose_file \
+  $(tlsverify) \
   $(verbose_option) \
   $(project_option) \
   $(command_arguments $command);

--- a/spec/integration/docker_compose_spec.rb
+++ b/spec/integration/docker_compose_spec.rb
@@ -132,6 +132,7 @@ describe "integration:docker-compose" do
       expect(out["sequence"].size).to be 2
       expect(out["sequence"][1]["exec-spec"]["args"]).to eq [
                                                                 "docker-compose",
+                                                                "--no-ansi",
                                                                 "--host",
                                                                 "foo:2376",
                                                                 "-f",
@@ -165,6 +166,7 @@ describe "integration:docker-compose" do
       expect(out["sequence"].size).to be 2
       expect(out["sequence"][1]["exec-spec"]["args"]).to eq [
                                                                 "docker-compose",
+                                                                "--no-ansi",
                                                                 "--host",
                                                                 "foo:2376",
                                                                 "-f",
@@ -202,6 +204,7 @@ describe "integration:docker-compose" do
       expect(out["sequence"].size).to be 2
       expect(out["sequence"][1]["exec-spec"]["args"]).to eq [
                                                                 "docker-compose",
+                                                                "--no-ansi",
                                                                 "--host",
                                                                 "foo:2376",
                                                                 "-f",
@@ -235,6 +238,7 @@ describe "integration:docker-compose" do
       expect(out["sequence"].size).to be 2
       expect(out["sequence"][1]["exec-spec"]["args"]).to eq [
                                                                 "docker-compose",
+                                                                "--no-ansi",
                                                                 "--host",
                                                                 "foo:2376",
                                                                 "-f",
@@ -265,6 +269,7 @@ describe "integration:docker-compose" do
       expect(out["sequence"].size).to be 2
       expect(out["sequence"][1]["exec-spec"]["args"]).to eq [
                                                                 "docker-compose",
+                                                                "--no-ansi",
                                                                 "--host",
                                                                 "foo:2376",
                                                                 "-f",
@@ -298,6 +303,7 @@ describe "integration:docker-compose" do
       expect(out["sequence"].size).to be 2
       expect(out["sequence"][1]["exec-spec"]["args"]).to eq [
                                                                 "docker-compose",
+                                                                "--no-ansi",
                                                                 "--host",
                                                                 "foo:2376",
                                                                 "-f",
@@ -332,6 +338,7 @@ describe "integration:docker-compose" do
       expect(out["sequence"].size).to be 2
       expect(out["sequence"][1]["exec-spec"]["args"]).to eq [
                                                                 "docker-compose",
+                                                                "--no-ansi",
                                                                 "--host",
                                                                 "foo:2376",
                                                                 "-f",
@@ -363,6 +370,7 @@ describe "integration:docker-compose" do
       expect(out["sequence"].size).to be 2
       expect(out["sequence"][1]["exec-spec"]["args"]).to eq [
                                                                 "docker-compose",
+                                                                "--no-ansi",
                                                                 "--host",
                                                                 "foo:2376",
                                                                 "-f",
@@ -398,6 +406,7 @@ describe "integration:docker-compose" do
       expect(out["sequence"].size).to be 2
       expect(out["sequence"][1]["exec-spec"]["args"]).to eq [
                                                                 "docker-compose",
+                                                                "--no-ansi",
                                                                 "--host",
                                                                 "foo:2376",
                                                                 "-f",
@@ -428,6 +437,7 @@ describe "integration:docker-compose" do
       expect(out["sequence"].size).to be 2
       expect(out["sequence"][1]["exec-spec"]["args"]).to eq [
                                                                 "docker-compose",
+                                                                "--no-ansi",
                                                                 "--host",
                                                                 "foo:2376",
                                                                 "-f",
@@ -461,6 +471,7 @@ describe "integration:docker-compose" do
       expect(out["sequence"].size).to be 2
       expect(out["sequence"][1]["exec-spec"]["args"]).to eq [
                                                                 "docker-compose",
+                                                                "--no-ansi",
                                                                 "--host",
                                                                 "foo:2376",
                                                                 "-f",
@@ -491,6 +502,7 @@ describe "integration:docker-compose" do
       expect(out["sequence"].size).to be 2
       expect(out["sequence"][1]["exec-spec"]["args"]).to eq [
                                                                 "docker-compose",
+                                                                "--no-ansi",
                                                                 "--host",
                                                                 "foo:2376",
                                                                 "-f",
@@ -520,6 +532,7 @@ describe "integration:docker-compose" do
       expect(out["sequence"].size).to be 2
       expect(out["sequence"][1]["exec-spec"]["args"]).to eq [
                                                                 "docker-compose",
+                                                                "--no-ansi",
                                                                 "--host",
                                                                 "foo:2376",
                                                                 "-f",
@@ -560,6 +573,7 @@ describe "integration:docker-compose" do
       expect(out["sequence"].size).to be 2
       expect(out["sequence"][1]["exec-spec"]["args"]).to eq [
                                                                 "docker-compose",
+                                                                "--no-ansi",
                                                                 "--host",
                                                                 "foo:2376",
                                                                 "-f",
@@ -604,6 +618,7 @@ describe "integration:docker-compose" do
       expect(out["sequence"].size).to be 2
       expect(out["sequence"][1]["exec-spec"]["args"]).to eq [
                                                                 "docker-compose",
+                                                                "--no-ansi",
                                                                 "--host",
                                                                 "foo:2376",
                                                                 "-f",

--- a/spec/integration/output_spec.rb
+++ b/spec/integration/output_spec.rb
@@ -21,6 +21,6 @@ describe "integration:output" do
     stdout, stderr, status = Open3.capture3("#{out_file} .", :stdin_data => stdin)
 
     expect(status.success?).to be true
-    expect(stdout).to eq("{\"version\":{}}")
+    expect(stdout).to eq("{\n  \"version\": {\n    \"digest\": \"sha256:\"\n  }\n}\n")
   end
 end


### PR DESCRIPTION
The PR contains the following:
* Fix a jq error when services parameter is empty
* Add TLS auth for docker host: this can be used in conjunction with kekru/docker-remote-api-tls image to secure the docker daemon (see also https://gist.github.com/kekru/4e6d49b4290a4eebc7b597c07eaf61f2)
* Refactor Dockerfile to be based on the official docker/compose image, which is lighter as it is based on Alpine
* Refine output of the resource to contain the SHA256 sum of the docker-compose.yml: in my case the file is different from build to build because the image is updated.